### PR TITLE
Fix to avoid Exception when using Nullable types for filtering

### DIFF
--- a/src/qdata.unittest/TestUtility.cs
+++ b/src/qdata.unittest/TestUtility.cs
@@ -14,9 +14,9 @@ namespace RoyLab.QData
         {
             users = new[]
             {
-                new User {Name = "Alice", Age = 10, Location = Location.SanFrancisco},
+                new User {Name = "Alice", Age = 10, Location = Location.SanFrancisco, ParentalDay = DateTime.Now},
                 new User {Name = "Bob", Age = 18, Location = Location.NewYork},
-                new User {Name = "Roy", Age = 24, Location = Location.SanFrancisco},
+                new User {Name = "Roy", Age = 24, Location = Location.SanFrancisco, ParentalDay = DateTime.Now},
                 new User {Name = "Jack", Age = 30, Location = Location.NewYork}
             };
         }
@@ -25,6 +25,14 @@ namespace RoyLab.QData
         public void TestFilter()
         {
             var resultSet = users.AsQueryable()
+               .QueryDynamic(null, $"ParentalDay<={DateTime.Now.AddDays(1)}")
+               .OfType<object>()
+               .ToList();
+            Assert.AreEqual(2, resultSet.Count);
+            Assert.AreSame(users[0], resultSet[0]);
+            Assert.AreSame(users[2], resultSet[1]);
+
+            resultSet = users.AsQueryable()
                 .QueryDynamic(null, "Age<20")
                 .OfType<object>()
                 .ToList();

--- a/src/qdata/Converters/ExpressionTrees/ExpressionTreesExpressionVisitor.cs
+++ b/src/qdata/Converters/ExpressionTrees/ExpressionTreesExpressionVisitor.cs
@@ -1,8 +1,8 @@
-using System.Linq;
-using System.Linq.Expressions;
-using RoyLab.QData.Filter.Expressions;
+﻿using RoyLab.QData.Filter.Expressions;
 using RoyLab.QData.Interfaces;
 using RoyLab.QData.Updater.Expressions;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace RoyLab.QData.Converters.ExpressionTrees
 {
@@ -50,7 +50,7 @@ namespace RoyLab.QData.Converters.ExpressionTrees
                 return null;
             }
 
-            var valueExpression = TypeUtility.Parse(Expression.Constant(compareExpression.Value), memberType);
+            var valueExpression = TypeUtility.TryParse(Expression.Constant(compareExpression.Value), memberType);
 
             return compareExpression.Operation switch
             {


### PR DESCRIPTION
Exception example:
System.InvalidOperationException : The binary operator LessThanOrEqual is not defined for the types 'System.Nullable`1[System.DateTime]' and 'System.DateTime'.
